### PR TITLE
[fix] use consistent preprocessed dataset id for train job and preprocess service

### DIFF
--- a/jobs/training-job/README.md
+++ b/jobs/training-job/README.md
@@ -7,7 +7,7 @@ Cloud Run job that executes fine-tuning on Gemma models.
 - **`main.py`** - Job entry point, loads config and starts training
 - **`training_service.py`** - Core training logic with provider support
 - **`job_manager.py`** - Job state tracking and Firestore integration
-- **`model_storage.py`** - Model saving/loading from GCS/HF Hub
+- **`storage.py`** - Model and dataset saving/loading from GCS/HF Hub
 - **`schema.py`** - Training configuration models
 
 ## Deployment
@@ -15,6 +15,10 @@ Cloud Run job that executes fine-tuning on Gemma models.
 ```bash
 gcloud builds submit --config cloudbuild.yaml --ignore-file=.gcloudignore
 ```
+
+- Cloud Run job with GPU support (L4)
+- Memory: 16Gi, CPU: 4 cores
+- GPU: 1x NVIDIA L4
 
 ## Execution Flow
 
@@ -67,9 +71,3 @@ gcloud builds submit --config cloudbuild.yaml --ignore-file=.gcloudignore
 - **Weights & Biases**: Training metrics and model logging
 - **Firestore**: Job status tracking
 - **Cloud Logging**: Execution logs
-
-## Deployment
-
-- Cloud Run job with GPU support (L4)
-- Memory: 16Gi, CPU: 4 cores
-- GPU: 1x NVIDIA L4

--- a/jobs/training-job/training_service.py
+++ b/jobs/training-job/training_service.py
@@ -1,7 +1,7 @@
 import logging
 import torch
 from abc import ABC, abstractmethod
-from model_storage import storage_service, StorageStrategyFactory
+from storage import storage_service, StorageStrategyFactory
 from schema import TrainRequest, WandbConfig
 from typing import Optional, Tuple, List, Dict, Any
 from job_manager import JobTracker

--- a/training/schema.py
+++ b/training/schema.py
@@ -32,7 +32,7 @@ class WandbConfig(BaseModel):
 class TrainRequest(BaseModel):
     job_name: str
     # This struct is shared between the API and the backend service
-    processed_dataset_id: str
+    processed_dataset_id: str  # this is dataset_name for now
     # NOTE: This is marked optional for dev but in deployment it should be required
     hf_token: Optional[str] = None
     training_config: TrainingConfig


### PR DESCRIPTION
as title, for documentation purpose:

- dataset is identified by `dataset_name` chosen by the user (should not contain space), which must be unique (validated by preprocess endpoint)
- train job id is created by: `training_{dataset_name}_{base_model_id}_{short_hash}` where `short_hash` is generated based on the request JSON -- this ensures that identical requests have identical ID deterministically

Also have validated that e2e testing is passing for the previous few PRs and frontend integration as well
