### PR TITLE
[hotfix] keep messages content type consistent for text and vision

### DIFF
--- a/preprocessing/README.md
+++ b/preprocessing/README.md
@@ -125,6 +125,8 @@ Get dataset information.
 }
 ```
 
+> NOTE: Modality is returned when you fetch info for a dataset and it is determined by the service and saved to metadata during processing. It is not set by the user.
+
 ### GET `/health`
 
 Health check endpoint.
@@ -139,16 +141,30 @@ Health check endpoint.
 
 ## ChatML Format
 
-Datasets are converted to the standardized ChatML format for conversational AI training. This format supports both text-only and multimodal (vision) conversations.
+Datasets are converted to the standardized ChatML format for conversational AI training. This format supports both text-only and multimodal (vision) conversations. We have standardized to use list format (containing "type") in `content` field for consistency between vision and text datasets.
 
 ### Text ChatML Example
 
 ```json
 {
   "messages": [
-    { "role": "system", "content": "You are a helpful assistant." },
-    { "role": "user", "content": "What is machine learning?" },
-    { "role": "assistant", "content": "Machine learning is a field of AI..." }
+    {
+      "role": "system",
+      "content": [{ "type": "text", "text": "You are a helpful assistant." }]
+    },
+    {
+      "role": "user",
+      "content": [{ "type": "text", "text": "What is deep learning?" }]
+    },
+    {
+      "role": "assistant",
+      "content": [
+        {
+          "type": "text",
+          "text": "Deep learning is a subset of machine learning..."
+        }
+      ]
+    }
   ]
 }
 ```

--- a/preprocessing/services/format_converter.py
+++ b/preprocessing/services/format_converter.py
@@ -466,8 +466,21 @@ class FormatConverter:
         user_content = (
             self._extract_multimodal_content(example, field_mappings, "user")
             if is_multimodal
-            else self._extract_text_content(example, field_mappings, "user")
+            else [
+                {
+                    "type": "text",
+                    "text": self._extract_text_content(example, field_mappings, "user"),
+                }
+            ]
         )
+
+        # Filter out empty text content
+        if is_multimodal:
+            user_content = [
+                item for item in user_content if item.get("text") or item.get("image")
+            ]
+        else:
+            user_content = [item for item in user_content if item.get("text")]
 
         if user_content:
             return {"role": "user", "content": user_content}


### PR DESCRIPTION
See the change in README.md. This now uses `"content": List[Dict]` type for both vision and text only instead of `"content: str` for text only to avoid inconsistencies.