### PR TITLE
[feat] [refactor] Support prompt-only and preference dataset formats

### DIFF
--- a/jobs/training-job/README.md
+++ b/jobs/training-job/README.md
@@ -31,106 +31,166 @@ gcloud builds submit --config cloudbuild.yaml --ignore-file=.gcloudignore
 6. **Track**: Update job status in Firestore
 7. **Export**: Save model to GCS or push to HF Hub
 
-## Training Methods
+## Required Configurations
 
-- **LoRA**: Low-rank adaptation (memory efficient)
-- **QLoRA**: Quantized LoRA (4-bit precision)
-- **Full**: Full fine-tuning (requires more memory)
-- **RL**: Reinforcement learning fine-tuning
+To create a training job, the following information must be provided or a default option will be used.
 
-## Providers
+### Modaltiy
 
-- **unsloth**: Optimized training with Unsloth library
+- **text**: Text-based models (e.g., Gemma3 1B)
+- **vision**: Multimodal models (e.g., Gemma3 4B)
+- **audio**: Audio-based models (e.g., Gemma3n, THIS IS NOT YET SUPPORTED!)
+
+### Providers
+
+- **unsloth**: Optimized training with Unsloth library _<-- default_
 - **huggingface**: Standard HuggingFace training
 
-## Configuration
+### PEFT + Quantisation
 
-**Environment Variables:**
+- **Full**: Full fine-tuning (requires more memory)
+- **LoRA**: Low-rank adaptation (memory efficient)
+- **QLoRA**: Quantized LoRA (4-bit precision) _<-- default_
 
-- `JOB_ID` - Unique job identifier
-- `PROJECT_ID` - GCP project for Firestore
-- `GCS_CONFIG_BUCKET_NAME` - Bucket for training configs
+### Trainer
 
-**Training Config:**
+> This only supports trainers in the TRL (transformers reinforcement learning) library. Dataset checks are not enforced for now but will be later!! Please use your judgement for now since it will just break otherwise...
 
-> NOTE: This is completely identically shared with `TrainRequest` and `TrainConfig` from `training/README.md`
+- **SFTTrainer**: require `language-modelling` or `prompt-completion` type dataset _<-- default_
+- **GRPOTrainer**: Used for reasoning tasks, require `prompt-only` type dataset
+- **DPOTrainer**: Used for preference tuning, require `preference` type dataset
+
+### Hyperparameters
+
+All hyperparameters are grouped under the `hyperparameters` section of the config. Example fields:
 
 ```json
-{
-  "processed_dataset_id": "dataset_abc123",
-  "hf_token": "hf_...",
-  "training_config": {
-    "method": "LoRA",
-    "base_model_id": "google/gemma-2b",
-    "learning_rate": 0.0001,
-    "batch_size": 4,
-    "epochs": 3,
-    "eval_strategy": "epoch",
-    "evaluation_metrics": ["accuracy", "perplexity"]
-  },
-  "export_config": {
-    "format": "merged",
-    "quantization": "fp16",
-    "destination": "gcs"
-  }
+"hyperparameters": {
+  "learning_rate": 0.0002,
+  "batch_size": 4,
+  "gradient_accumulation_steps": 4,
+  "epochs": 3,
+  "max_steps": -1,
+  "packing": false,
+  "use_fa2": false,
+  "max_seq_length": 2048,
+  "lr_scheduler_type": "linear",
+  "save_strategy": "epoch",
+  "logging_steps": 10,
+  "lora_rank": 16,
+  "lora_alpha": 16,
+  "lora_dropout": 0.05
 }
 ```
 
-## Monitoring
+**Field descriptions:**
 
-- **Weights & Biases**: Training metrics and model logging
-- **Firestore**: Job status tracking
-- **Cloud Logging**: Execution logs
+- `learning_rate`: Learning rate for optimizer (default: 2e-4)
+- `batch_size`: Per-device batch size (default: 2)
+- `gradient_accumulation_steps`: Number of steps to accumulate gradients (default: 4)
+- `epochs`: Number of epochs to train (default: 3)
+- `max_steps`: Maximum number of steps to train (default: -1 for unlimited)
+- `packing`: Whether to use sequence packing (default: false, only works with FA2)
+- `use_fa2`: Use FlashAttention-2 (default: false, only available for HuggingFace provider)
+- `max_seq_length`: Maximum sequence length for model/tokenizer
+- `lr_scheduler_type`: Learning rate scheduler type (default: "linear")
+- `save_strategy`: When to save checkpoints (default: "epoch")
+- `logging_steps`: Logging frequency (default: 10)
+- `lora_rank`, `lora_alpha`, `lora_dropout`: LoRA/QLoRA PEFT parameters (used if method is LoRA/QLoRA)
 
-## Export Formats
+### Export
 
-### Adapter Export
+All export options are grouped under the `export_config` section of the config. Example fields:
 
-- **Format**: `adapter`
-- **Quantization**: Not applicable
-- **Use case**: Lightweight LoRA/QLoRA adapter weights only
-- **Storage**: ~MB in size, fast upload/download
+```json
+"export_config": {
+  "format": "adapter",           // "adapter" or "merged"
+  "destination": "gcs",          // "gcs" or "hfhub"
+  "hf_repo_id": null,             // HuggingFace repo ID (if using hfhub)
+  "include_gguf": false,          // Whether to also export GGUF format
+  "gguf_quantization": null       // GGUF quantization type (see below)
+}
+```
 
-### Merged Export
+**Field descriptions:**
 
-- **Format**: `merged`
-- **Quantization**: `none`, `fp16`, `q4` (4-bit)
-- **Use case**: Full standalone model for deployment
-- **Providers**:
-  - Unsloth: `merged_16bit` (vLLM compatible), `merged_4bit`
-  - HuggingFace: Standard merge with PEFT, supports FP16 quantization
+- `format`: Export format, either `adapter` (LoRA/QLoRA weights only, default) or `merged` (full model, usually f16 for vLLM)
+- `destination`: Where to export the model (`gcs` for Google Cloud Storage, `hfhub` for HuggingFace Hub)
+- `hf_repo_id`: (Optional) HuggingFace repo ID for upload
+- `include_gguf`: (Optional) Also export a GGUF file for CPU inference (default: false)
+- `gguf_quantization`: (Optional) GGUF quantization type, one of: `none`, `f16`, `bf16`, `q8_0`, `q4_k_m` (default: `q8_0`)
 
-### GGUF Export
+## Optional Configurations
 
-- **Format**: `gguf`
-- **Quantization**: `f16`, `q8_0`, `q4_k_m`, `q5_k_m`, `q2_k`
-- **Use case**: CPU-optimized inference (llama.cpp, Ollama)
-- **Providers**:
-  - Unsloth: Native GGUF export with quantization
-  - HuggingFace: Not implemented (requires llama.cpp conversion)
+The following features will be turned off by default if not provided.
 
-## Evaluation
+### Evaluation
 
 Configure evaluation during training:
 
 - **eval_strategy**: When to run evaluation (`no`, `steps`, `epoch`)
 - **eval_steps**: Evaluation frequency when using `steps` strategy
-- **evaluation_metrics**: Metrics to compute (`accuracy`, `perplexity`)
+- **evaluation_metrics**: `true/false` whether to compute evaluation metrics (accuracy and perplexity, token level)
 - **batch_eval_metrics**: Enable batch evaluation mode for better performance
 
-Supported metrics:
+> If you want task-specific metrics, currently they are only supported in the inference service with the `evaluation` endpoint
 
-- **Accuracy**: Token-level classification accuracy
-- **Perplexity**: Model confidence metric (2^loss)
-- **Loss**: Training/validation loss
+### Monitoring
 
-> If you want more complicated metrics, currently they are only supported in the inference service, you can use the `/evaluate` endpoint there.
+- **wandb**: Provide your wandb API key and other variables to set up cloud logging
+- **streaming logs**: Stream logs to frontend or a CLI whatever toolkit (NOT SUPPORTED, PLANNED)
+
+## Example Training Config
+
+I will update this later...
+
+**Training Config:**
+
+> NOTE: This is completely identically shared with `TrainingConfig` from `training/schema.py`. This describes the `training_config` field, not the entire request.
+
+```json
+{
+  "base_model_id": "google/gemma-2b",
+  "provider": "huggingface",
+  "method": "LoRA",
+  "trainer_type": "sft",
+  "modality": "text",
+  "hyperparameters": {
+    "learning_rate": 0.0001,
+    "batch_size": 4,
+    "gradient_accumulation_steps": 4,
+    "epochs": 3,
+    "max_steps": -1,
+    "packing": false,
+    "use_fa2": false,
+    "max_seq_length": 2048,
+    "lr_scheduler_type": "linear",
+    "save_strategy": "epoch",
+    "logging_steps": 10,
+    "lora_rank": 16,
+    "lora_alpha": 16,
+    "lora_dropout": 0.05
+  },
+  "export_config": {
+    "format": "merged",
+    "destination": "gcs",
+    "hf_repo_id": null,
+    "include_gguf": false,
+    "gguf_quantization": null
+  },
+  "eval_config": {
+    "eval_strategy": "epoch",
+    "eval_steps": 50,
+    "compute_eval_metrics": true,
+    "batch_eval_metrics": false
+  },
+  "wandb_config": null
+}
+```
 
 ## Known Issues
 
 - GGUF export is currently not supported by HuggingFace but you can do it manually using `llama.cpp` or `ollama` tools.
-
-- GGUF export for Unsloth is being fixed by the unsloth team...
 
 - Evaluation during training is not supported for Unsloth, this might be worked on by unsloth team (use eval in inference service instead)
 

--- a/jobs/training-job/main.py
+++ b/jobs/training-job/main.py
@@ -110,7 +110,9 @@ def main():
             train_req = TrainRequest.model_validate(train_request)
             service = TrainingService.from_provider(train_req.training_config.provider)
             # We don't need to return anything because they are saved by the tracker internally to firestore already
-            _ = service.run_training(train_req, tracker)
+            _ = service.run_training(
+                train_req.processed_dataset_id, train_req.training_config, tracker
+            )
     except Exception as e:
         logging.error(f"Training job {job_id} failed: {str(e)}", exc_info=True)
         # Exception handling is done by JobTracker context manager

--- a/jobs/training-job/schema.py
+++ b/jobs/training-job/schema.py
@@ -1,35 +1,33 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from typing import Literal, Optional
 
 
-class TrainingConfig(BaseModel):
-    method: Literal["Full", "LoRA", "QLoRA", "RL"]
-    base_model_id: str
-    lora_rank: Optional[int] = 16
-    lora_alpha: Optional[int] = 16
-    lora_dropout: Optional[float] = 0.05
+class HyperparameterConfig(BaseModel):
+    """Training hyperparameters configuration"""
 
+    # Basic hyperparameters
     learning_rate: float = 2e-4
-    # Seems like batch size = 8 will cause OOM on the L4 on Cloud Run
-    batch_size: int = 4
-    gradient_accumulation_steps: int = 4
-    epochs: int = 3
-    # Default this to -1 instead of None to avoid operator errors
-    max_steps: Optional[int] = -1
+    batch_size: int = 2  # batch size > 4 might cause OOM sometimes
+    gradient_accumulation_steps: int = 4  # effective batch sz = 2*4 = 8
+    epochs: int = 3  # ignored when max_steps provided
+    max_steps: Optional[int] = -1  # Default to -1 instead of None to avoid operator err
 
-    # NOTE: Packing only works with FA2
-    packing: bool = False  # whether to pack sequences for training
+    # Technical and optimization settings
+    packing: bool = False  # whether to pack sequences for training, only works with FA2
     use_fa2: bool = False  # FA2 is only available when provider is "huggingface"
-
-    provider: Literal["unsloth", "huggingface"] = "huggingface"
-
-    # Vision training configuration
-    modality: Literal["text", "vision"] = "text"
-
     max_seq_length: Optional[int] = None  # used to load pretrained models
     lr_scheduler_type: Optional[str] = "linear"
     save_strategy: Optional[str] = "epoch"
     logging_steps: Optional[int] = 10
+
+    # PEFT Config -- should be present if method is LoRA or QLoRA
+    lora_rank: Optional[int] = 16
+    lora_alpha: Optional[int] = 16
+    lora_dropout: Optional[float] = 0.05
+
+
+class EvaluationConfig(BaseModel):
+    """Evaluation configuration during training"""
 
     # NOTE: Only specify eval_strategy if you actually provide eval_dataset
     eval_strategy: Optional[str] = "no"  # "no", "steps", "epoch"
@@ -43,9 +41,10 @@ class TrainingConfig(BaseModel):
 
 
 class WandbConfig(BaseModel):
+    """Configuration for wandb monitoring, will extend to be a subclass of MonitoringConfig later"""
+
     api_key: str
-    # project is defaulted to "huggingface" if not provided
-    project: Optional[str] = None
+    project: Optional[str] = None  # defaulted to "huggingface" if not provided
     log_model: Optional[Literal["false", "checkpoint", "end"]] = "end"
 
 
@@ -68,11 +67,37 @@ class ExportConfig(BaseModel):
     ] = None
 
 
+class TrainingConfig(BaseModel):
+    """Unified config structure for training, all customizations should be included here and ONLY here"""
+
+    # Core configurations
+    base_model_id: str
+    provider: Literal["unsloth", "huggingface"] = "huggingface"
+    method: Literal["Full", "LoRA", "QLoRA"] = "QLoRA"
+    trainer_type: Literal["sft", "dpo", "grpo"] = "sft"
+    modality: Literal["text", "vision"] = "text"
+
+    # Grouped configurations
+    hyperparameters: HyperparameterConfig = HyperparameterConfig()
+    export_config: ExportConfig = ExportConfig()
+
+    # Optional configurations
+    eval_config: Optional[EvaluationConfig] = None
+    wandb_config: Optional[WandbConfig] = None
+
+    @field_validator("trainer_type")
+    @classmethod
+    def validate_trainer_compatibility(cls, v, info):
+        """Validate trainer type compatibility with other config"""
+        # Validation for trainer compatibility will be added later...
+        return v
+
+
+# NOTE: This struct is shared between the API and the backend service
 class TrainRequest(BaseModel):
-    # This struct is shared between the API and the backend service
+    """Request schema for training job, only TrainingConfig will be accessible in backend"""
+
     processed_dataset_id: str
     hf_token: str
     job_name: str = "unnamed job"
     training_config: TrainingConfig
-    export_config: ExportConfig
-    wandb_config: Optional[WandbConfig] = None

--- a/preprocessing/README.md
+++ b/preprocessing/README.md
@@ -2,7 +2,10 @@
 
 FastAPI service for preprocessing datasets for Gemma fine-tuning. Handles uploading, processing, and storing datasets in Google Cloud Storage or the local file system.
 
+> [!NOTE]
 > This service chooses to use conversational format with the ChatML variation. It covers multiple use cases by supporting different types.
+> [!CAUTION]
+> This service is not responsible for applying chat template and tokenizing / applying processors. This is a huge difference with some documentation that you will see on TRL, HF, or Unsloth. We have a specialized vision collator to do these **during training** (because it is meaningless to save these tokens in the dataset).
 
 ## Structure
 
@@ -260,6 +263,8 @@ Planned:
       "role": "user",
       "content": [
         { "type": "text", "content": "What color is the sky?" },
+        // This differs to some documentation because we extract this image
+        // and apply processor during training not during preprocessing
         { "type": "image", "image": "<base64 or image object>" }
       ]
     }
@@ -272,7 +277,7 @@ Planned:
 
 ## Conversion Configuration
 
-### Language Modeling (Vision)
+### Language Modeling
 
 Vision processing is automatically enabled when image field mappings are detected. Simply add image field mappings to your configuration (you can include multiple images in a single user message).
 
@@ -310,7 +315,7 @@ Vision processing is automatically enabled when image field mappings are detecte
 - Images are processed in the order they appear in the field_mappings
 - Supported image formats: PIL Image objects, base64 strings, file paths, HuggingFace dataset format with `bytes` field
 
-### Prompt-only (Text)
+### Prompt-only
 
 ```json
 {
@@ -324,6 +329,10 @@ Vision processing is automatically enabled when image field mappings are detecte
       "user_field": {
         "type": "template",
         "value": "This is the user's prompt {prompt}."
+      },
+      "image_to_add_to_user": {
+        "type": "image",
+        "value": "image"
       },
       "answer": {
         "type": "column",
@@ -343,6 +352,7 @@ Vision processing is automatically enabled when image field mappings are detecte
 ```
 
 - `user_field` and `system_field` work the same way as in language modeling, but the `assistant_field` is not used.
+- Unlike language modeling, current research indicates that ONLY ONE image is allowed, but the conversion works the same
 
 ## Metadata Management
 

--- a/preprocessing/README.md
+++ b/preprocessing/README.md
@@ -1,6 +1,8 @@
 # Preprocessing Service
 
-FastAPI service for preprocessing datasets for Gemma fine-tuning. Handles uploading, processing, and storing datasets in Google Cloud Storage or the local file system. Supports both text and vision (multimodal) ChatML format conversion.
+FastAPI service for preprocessing datasets for Gemma fine-tuning. Handles uploading, processing, and storing datasets in Google Cloud Storage or the local file system.
+
+> This service chooses to use conversational format with the ChatML variation. It covers multiple use cases by supporting different types.
 
 ## Structure
 
@@ -49,6 +51,10 @@ Start preprocessing job (supports text and vision datasets).
 ```json
 {
   "dataset_name": "your_dataset_name",
+  "dataset_source": "huggingface",
+  "dataset_id": "org/repo",
+  "dataset_subset": "default",
+  "processing_mode": "language_modeling" | "prompt_only",
   "config": {
     /* field mappings and options, see below */
   }
@@ -59,8 +65,9 @@ Start preprocessing job (supports text and vision datasets).
 
 ```json
 {
-  "status": "processing_started",
-  "processed_dataset": "your_dataset_name_processed"
+  "dataset_name": "your_dataset_name"
+  // OTHER METADATA FIELDS NOT USED BY THE FRONTEND
+  // the frontend redirects to the `/datasets/{processed_dataset_id}` endpoint directly
 }
 ```
 
@@ -98,15 +105,6 @@ Get dataset information.
         "num_rows": 1000,
         "path": "processed_datasets/your_dataset_name/train.parquet",
         "samples": [
-          // For text datasets:
-          {
-            "messages": [
-              { "role": "system", "content": "You are a helpful assistant." },
-              { "role": "user", "content": "What is machine learning?" },
-              { "role": "assistant", "content": "Machine learning is a field of AI..." }
-            ]
-          },
-          // ... up to 5 samples
           // For vision datasets:
           {
             "messages": [
@@ -122,6 +120,7 @@ Get dataset information.
               { "role": "assistant", "content": "The first image shows..." }
             ]
           }
+          // up to five samples per split...
         ]
       },
       // ... more splits (e.g., "test")
@@ -130,7 +129,9 @@ Get dataset information.
 }
 ```
 
-> NOTE: Modality is returned when you fetch info for a dataset and it is determined by the service and saved to metadata during processing. It is not set by the user.
+> NOTE: Modality is returned when you fetch info for a dataset and it is determined by the service and saved to metadata during processing. It is NOT set by the user.
+
+> Samples dict is structured according to the ChatML format and the specific type of the dataset (as well as modality). See the [Conversion Examples](#conversion-examples) section for details.
 
 ### DELETE `/datasets/{processed_dataset_id}`
 
@@ -156,19 +157,44 @@ Delete a dataset and all associated files.
 
 Health check endpoint.
 
-## Supported Formats
+## Conversion Examples
 
-- JSON, JSONL, CSV, Parquet, Excel files
-- HuggingFace datasets
-- **Vision datasets** with image columns (JPEG, PNG, BMP, GIF, TIFF, WebP)
+The only format used in this project is conversation format as opposed to standard format defined in TRL docs. The specific variation of this format used in ChatML. The reason is that this format supports both text-only and multimodal (vision) conversations.
 
-> **Note:** Uploading custom vision datasets is not currently supported, but you can use existing HuggingFace multimodal datasets.
+We have standardized to use list format (containing `type`) in `content` field for consistency between vision and text datasets, **even if the dataset is text-only**. The handler is backward compatible but this format is always preferred for consistency.
 
-## ChatML Format
+### Supported Formats & Modes
 
-Datasets are converted to the standardized ChatML format for conversational AI training. This format supports both text-only and multimodal (vision) conversations. We have standardized to use list format (containing "type") in `content` field for consistency between vision and text datasets.
+This service can ingest standard tabular formats (JSON, JSONL, CSV, Parquet, Excel) and HuggingFace datasets. It then preprocesses them into specific conversational formats tailored for different fine-tuning tasks. The desired output is controlled via a `processing_mode` parameter in the process request.
 
-### Text ChatML Example
+- **Language Modeling (`language_modeling`)**
+
+  - **Use Case**: Continued pre-training or domain adaptation using `SFTTrainer`.
+  - **Output Format**: The source text is mapped to the `assistant` role in a single-turn conversation. This presents the text as a valid completion for the model to learn from without a direct prompt.
+
+- **Prompt-Only (`prompt_only`)**
+  - **Use Case**: Policy optimization with trainers that require only a prompt, such as `GRPOTrainer`. The trainer uses the prompt to generate its own responses for optimization.
+  - **Output Format**: The source prompt is mapped to the `user` role in a single-turn conversation.
+
+Examples are shown below.
+
+Planned:
+
+- **Instruction Tuning (`prompt_completion`)**
+
+  - **Use Case**: Standard supervised fine-tuning with `SFTTrainer` to teach the model to follow instructions.
+  - **Source Data**: Two columns for `prompt` and `completion`.
+  - **Output Format**: A standard two-turn conversation.
+  - **Example**: `{"messages": [{"role": "user", "content": "..."}, {"role": "assistant", "content": "..."}]}`
+
+- **Preference Tuning (`preference`)**
+  - **Use Case**: Alignment with preference-based algorithms like DPO using `DPOTrainer`.
+  - **Source Data**: Three columns: `prompt`, `chosen` (the preferred response), and `rejected` (the less-preferred response).
+  - **Output Format**: This mode will produce a dataset with three distinct columns (`prompt`, `chosen`, `rejected`), as this specific structure is required by the `DPOTrainer`.
+
+### Language Modelling
+
+#### Text Example
 
 ```json
 {
@@ -194,12 +220,15 @@ Datasets are converted to the standardized ChatML format for conversational AI t
 }
 ```
 
-### Vision ChatML Example
+#### Vision Example
 
 ```json
 {
   "messages": [
-    { "role": "system", "content": "Describe the images." },
+    {
+      "role": "system",
+      "content": [{ "type": "text", "text": "Describe the images." }]
+    },
     {
       "role": "user",
       "content": [
@@ -208,14 +237,42 @@ Datasets are converted to the standardized ChatML format for conversational AI t
         { "type": "image", "image": "<base64 or image object>" }
       ]
     },
-    { "role": "assistant", "content": "The first image shows..." }
+    {
+      "role": "assistant",
+      "content": [{ "type": "text", "text": "The first image shows..." }]
+    }
   ]
 }
 ```
 
 > **Note:** Images are always included in the user message as a list of content items. See below for vision configuration.
 
-## Vision Configuration
+### Prompt-Only
+
+```json
+{
+  "prompt": [
+    {
+      "role": "system",
+      "content": [{ "type": "text", "content": "REASONING_PROMPT" }]
+    },
+    {
+      "role": "user",
+      "content": [
+        { "type": "text", "content": "What color is the sky?" },
+        { "type": "image", "image": "<base64 or image object>" }
+      ]
+    }
+  ],
+  "answer": "10",
+  "reasoning": "<think>Some math logic</think>",
+  "any_other_additional_fields": "additional_info"
+}
+```
+
+## Conversion Configuration
+
+### Language Modeling (Vision)
 
 Vision processing is automatically enabled when image field mappings are detected. Simply add image field mappings to your configuration (you can include multiple images in a single user message).
 
@@ -253,6 +310,40 @@ Vision processing is automatically enabled when image field mappings are detecte
 - Images are processed in the order they appear in the field_mappings
 - Supported image formats: PIL Image objects, base64 strings, file paths, HuggingFace dataset format with `bytes` field
 
+### Prompt-only (Text)
+
+```json
+{
+  "config": {
+    "vision_enabled": true,
+    "field_mappings": {
+      "system_field": {
+        "type": "template",
+        "value": "This is how you should reason... put stuff in this tag... put answer in..."
+      },
+      "user_field": {
+        "type": "template",
+        "value": "This is the user's prompt {prompt}."
+      },
+      "answer": {
+        "type": "column",
+        "value": "answer"
+      },
+      "reasoning": {
+        "type": "column",
+        "value": "reasoning"
+      },
+      "any_other_additional_fields": {
+        "type": "column",
+        "value": "additional_info"
+      }
+    }
+  }
+}
+```
+
+- `user_field` and `system_field` work the same way as in language modeling, but the `assistant_field` is not used.
+
 ## Metadata Management
 
 The preprocessing service uses a hybrid storage approach:
@@ -261,8 +352,3 @@ The preprocessing service uses a hybrid storage approach:
 - **Metadata**: Centrally managed in Firestore for consistency and user ownership tracking
 
 Each preprocessed dataset is identified by a unique 8-char UUID based identifier, this field is called `processed_dataset_id`. It is used as the ID for the document and firestore and the folder in GCS. This is different from `dataset_id` which refers to the ID of the **source** dataset, e.g. ID at hugging face or uploaded files.
-
-## Environment Variables
-
-- `GCS_DATA_BUCKET_NAME`: Google Cloud Storage bucket name (required for GCS storage)
-- See `.env.example` for more options

--- a/preprocessing/app.py
+++ b/preprocessing/app.py
@@ -172,6 +172,7 @@ def process_dataset(
             dataset_source=request.dataset_source,
             dataset_id=request.dataset_id,
             dataset_subset=request.dataset_subset,
+            processing_mode=request.processing_mode,
             config=request.config,
         )
 

--- a/preprocessing/schema.py
+++ b/preprocessing/schema.py
@@ -87,7 +87,7 @@ class PreprocessingRequest(BaseModel):
         if self.processing_mode == ProcessingMode.LANGUAGE_MODELING:
             required_fields = ["user_field", "assistant_field"]
         elif self.processing_mode == ProcessingMode.PROMPT_ONLY:
-            required_fields = ["system_field", "user_field"]
+            required_fields = ["user_field"]
         elif self.processing_mode == ProcessingMode.PREFERENCE:
             required_fields = ["user_field", "chosen_field", "rejected_field"]
 

--- a/preprocessing/schema.py
+++ b/preprocessing/schema.py
@@ -10,6 +10,7 @@ class ProcessingMode(str, Enum):
 
     LANGUAGE_MODELING = "language_modeling"
     PROMPT_ONLY = "prompt_only"
+    PREFERENCE = "preference"
 
 
 class DatasetUploadResponse(BaseModel):
@@ -87,6 +88,8 @@ class PreprocessingRequest(BaseModel):
             required_fields = ["user_field", "assistant_field"]
         elif self.processing_mode == ProcessingMode.PROMPT_ONLY:
             required_fields = ["system_field", "user_field"]
+        elif self.processing_mode == ProcessingMode.PREFERENCE:
+            required_fields = ["user_field", "chosen_field", "rejected_field"]
 
         for field in required_fields:
             if field not in self.config.field_mappings:

--- a/preprocessing/services/dataset_handler.py
+++ b/preprocessing/services/dataset_handler.py
@@ -180,6 +180,7 @@ class DatasetHandler:
         dataset_subset: str,
         config: PreprocessingConfig,
         dataset_source: str,
+        modality: str,
     ) -> tuple[str, str, dict]:
         """
         Upload a processed dataset to storage with a unique identifier.
@@ -191,6 +192,7 @@ class DatasetHandler:
             dataset_subset (str): Subset of the dataset
             config (PreprocessingConfig): Configuration used for processing
             dataset_source (str): Source of the dataset ("upload" or "huggingface")
+            modality (str): Modality of the dataset ("text" or "vision")
 
         Returns:
             tuple[str, str, dict]: A tuple containing (dataset_path, processed_dataset_id, metadata)
@@ -211,12 +213,6 @@ class DatasetHandler:
         # Generate unique ID for processed dataset (8-character UUID hex)
         processed_dataset_id = str(uuid.uuid4()).replace("-", "")[:8]
 
-        # Automatically determine modality: 'vision' if any image field mappings, else 'text'
-        modality = (
-            "vision"
-            if any(fm.type == "image" for fm in config.field_mappings.values())
-            else "text"
-        )
         metadata = {
             "splits": [],
             "dataset_name": dataset_name,

--- a/preprocessing/services/dataset_service.py
+++ b/preprocessing/services/dataset_service.py
@@ -151,9 +151,11 @@ class DatasetService:
                 raise ValueError("Dataset is empty or could not be loaded")
 
             config_dict = config.model_dump()
-
-            processed_dataset = self.converter.convert_to_conversational_chatml(
-                dataset, processing_mode, config_dict
+            # the format converter will detect modality and return
+            processed_dataset, modality = (
+                self.converter.convert_to_conversational_chatml(
+                    dataset, processing_mode, config_dict
+                )
             )
 
             if not processed_dataset:
@@ -175,6 +177,7 @@ class DatasetService:
                     dataset_subset,
                     config,
                     dataset_source,
+                    modality,
                 )
             )
 
@@ -198,7 +201,10 @@ class DatasetService:
             return result
 
         except Exception as e:
+            import traceback
+
             logger.error(f"Error processing dataset: {str(e)}")
+            logger.error(f"Full traceback: {traceback.format_exc()}")
             raise
 
     def get_datasets_info(self, user_id: str, dataset_tracker) -> DatasetsInfoResponse:

--- a/preprocessing/services/dataset_service.py
+++ b/preprocessing/services/dataset_service.py
@@ -112,15 +112,16 @@ class DatasetService:
         dataset_name: str,
         dataset_source: Literal["upload", "huggingface"],
         dataset_id: str,
+        processing_mode: str,  # Changed from PreprocessingConfig
         config: PreprocessingConfig,
         dataset_subset: str = "default",
     ) -> ProcessingResult:
         """
-        Process a dataset to ChatML format.
+        Process a dataset to a conversational format based on the processing mode.
 
         This method performs the complete dataset processing pipeline:
         1. Loads the dataset from the specified source
-        2. Converts it to ChatML format
+        2. Converts it to a conversational format based on the mode
         3. Applies data augmentation if configured
         4. Validates the converted dataset
         5. Saves the processed dataset to storage
@@ -130,60 +131,17 @@ class DatasetService:
             dataset_name (str): The name of the dataset, used for the processed dataset name
             dataset_source (str): The source of the dataset
             dataset_id (str): The identifier for the dataset
-            config (PreprocessingConfig): Configuration for processing, including:
-                - field_mappings: Maps input fields to ChatML roles
-                - system_message: Default system message
-                - include_system: Whether to include system message
-                - user_template: Template for formatting user content
-                - train_test_split: Whether to split into train/test sets
-                - test_size: Size of test set (if splitting)
-                - augmentation_config: Configuration for data augmentation, including:
-                    - enabled: Whether to apply augmentation
-                    - use_eda: Whether to use Easy Data Augmentation
-                    - use_back_translation: Whether to use back translation
-                    - use_paraphrasing: Whether to use paraphrasing
-                    - use_synthesis: Whether to use AI synthesis
-                    - gemini_api_key: API key for Gemini (if using synthesis)
-                    - augmentation_factor: Factor to increase dataset size
-            sample_size (Optional[int]): Number of samples to process.
-                If None, processes the entire dataset.
+            processing_mode (str): The target format mode (e.g., 'language_modeling', 'grpo').
+            config (PreprocessingConfig): Configuration for processing, including field mappings.
+            dataset_subset (str): The subset of the dataset to use (for Hugging Face datasets).
 
         Returns:
             ProcessingResult: An object containing processing results and metadata
 
         Raises:
             Exception: If there's an error during processing
-
-        Example:
-            >>> config = PreprocessingConfig(
-            ...     field_mappings={
-            ...         "system_field": {"type": "template", "value": "You are a helpful assistant."},
-            ...         "user_field": {"type": "column", "value": "question"},
-            ...         "assistant_field": {"type": "template", "value": "Answer: {answer}"}
-            ...     },
-            ...     system_message="You are a helpful assistant.",
-            ...     train_test_split=True,
-            ...     test_size=0.2,
-            ...     augmentation_config={
-            ...         "enabled": True,
-            ...         "use_eda": True,
-            ...         "use_synthesis": True,
-            ...         "gemini_api_key": "your_api_key",
-            ...         "augmentation_factor": 1.5
-            ...     }
-            ... )
-            >>> result = service.process_dataset(
-            ...     "my_dataset",
-            ...     "upload",
-            ...     "my_dataset_id",
-            ...     config,
-            ...     split_config=HFSplitConfig(type="hf_split", splits=["train", "test"]),
-            ... )
         """
         try:
-            # Check if dataset name is already taken (we'll remove this check since we use unique IDs now)
-            # We can keep similar names as they will have different unique IDs
-
             # Load dataset with splits
             dataset = self.loader.load_dataset(
                 dataset_source, dataset_id, config, dataset_subset
@@ -194,7 +152,9 @@ class DatasetService:
 
             config_dict = config.model_dump()
 
-            processed_dataset = self.converter.convert_to_chatml(dataset, config_dict)
+            processed_dataset = self.converter.convert_to_conversational_chatml(
+                dataset, processing_mode, config_dict
+            )
 
             if not processed_dataset:
                 raise ValueError("No samples could be converted to ChatML format")

--- a/training/app.py
+++ b/training/app.py
@@ -165,8 +165,8 @@ async def start_training(
     job_id = make_job_id(processed_dataset_id, base_model_id, request)
 
     if (
-        request.export_config.destination == "hfhub"
-        and not request.export_config.hf_repo_id
+        request.training_config.export_config.destination == "hfhub"
+        and not request.training_config.export_config.hf_repo_id
     ):
         raise HTTPException(
             status_code=400,

--- a/training/schema.py
+++ b/training/schema.py
@@ -1,5 +1,51 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from typing import Literal, Optional, List
+
+
+class HyperparameterConfig(BaseModel):
+    """Training hyperparameters configuration"""
+
+    # Basic hyperparameters
+    learning_rate: float = 2e-4
+    batch_size: int = 2  # batch size > 4 might cause OOM sometimes
+    gradient_accumulation_steps: int = 4  # effective batch sz = 2*4 = 8
+    epochs: int = 3  # ignored when max_steps provided
+    max_steps: Optional[int] = -1  # Default to -1 instead of None to avoid operator err
+
+    # Technical and optimization settings
+    packing: bool = False  # whether to pack sequences for training, only works with FA2
+    use_fa2: bool = False  # FA2 is only available when provider is "huggingface"
+    max_seq_length: Optional[int] = None  # used to load pretrained models
+    lr_scheduler_type: Optional[str] = "linear"
+    save_strategy: Optional[str] = "epoch"
+    logging_steps: Optional[int] = 10
+
+    # PEFT Config -- should be present if method is LoRA or QLoRA
+    lora_rank: Optional[int] = 16
+    lora_alpha: Optional[int] = 16
+    lora_dropout: Optional[float] = 0.05
+
+
+class EvaluationConfig(BaseModel):
+    """Evaluation configuration during training"""
+
+    # NOTE: Only specify eval_strategy if you actually provide eval_dataset
+    eval_strategy: Optional[str] = "no"  # "no", "steps", "epoch"
+    eval_steps: Optional[int] = 50  # Required if eval_strategy="steps"
+
+    # Metrics configuration, otherwise eval only returns eval loss etc.
+    # if true returns computed metrics ["accuracy", "perplexity"]
+    compute_eval_metrics: Optional[bool] = False
+    # Set to True to enable batch evaluation mode for metrics computation
+    batch_eval_metrics: Optional[bool] = False
+
+
+class WandbConfig(BaseModel):
+    """Configuration for wandb monitoring, will extend to be a subclass of MonitoringConfig later"""
+
+    api_key: str
+    project: Optional[str] = None  # defaulted to "huggingface" if not provided
+    log_model: Optional[Literal["false", "checkpoint", "end"]] = "end"
 
 
 class ExportConfig(BaseModel):
@@ -21,6 +67,46 @@ class ExportConfig(BaseModel):
     ] = None
 
 
+class TrainingConfig(BaseModel):
+    """Unified config structure for training, all customizations should be included here and ONLY here"""
+
+    # Core configurations
+    base_model_id: str
+    provider: Literal["unsloth", "huggingface"] = "huggingface"
+    method: Literal["Full", "LoRA", "QLoRA"] = "QLoRA"
+    trainer_type: Literal["sft", "dpo", "grpo"] = "sft"
+    modality: Literal["text", "vision"] = "text"
+
+    # Grouped configurations
+    hyperparameters: HyperparameterConfig = HyperparameterConfig()
+    export_config: ExportConfig = ExportConfig()
+
+    # Optional configurations
+    eval_config: Optional[EvaluationConfig] = None
+    wandb_config: Optional[WandbConfig] = None
+
+    @field_validator("trainer_type")
+    @classmethod
+    def validate_trainer_compatibility(cls, v, info):
+        """Validate trainer type compatibility with other config"""
+        # Validation for trainer compatibility will be added later...
+        return v
+
+
+# NOTE: This struct is shared between the API and the backend service
+class TrainRequest(BaseModel):
+    """Request schema for training job, only TrainingConfig will be accessible in backend"""
+
+    processed_dataset_id: str
+    hf_token: str
+    job_name: str = "unnamed job"
+    training_config: TrainingConfig
+
+
+class JobSubmitResponse(BaseModel):
+    job_id: str
+
+
 class EvaluationMetrics(BaseModel):
     """
     Evaluation metrics structure to hold results after training.
@@ -31,68 +117,6 @@ class EvaluationMetrics(BaseModel):
     perplexity: Optional[float] = None
     eval_loss: Optional[float] = None
     eval_runtime: Optional[float] = None
-
-
-class TrainingConfig(BaseModel):
-    method: Literal["Full", "LoRA", "QLoRA", "RL"]
-    base_model_id: str
-    lora_rank: Optional[int] = 16
-    lora_alpha: Optional[int] = 16
-    lora_dropout: Optional[float] = 0.05
-
-    learning_rate: float = 2e-4
-    # Seems like batch size = 8 will cause OOM on the L4 on Cloud Run
-    # I haven't enforced a check yet but for prod we should probably limit this
-    batch_size: int = 4
-    gradient_accumulation_steps: int = 4
-    epochs: int = 3
-    # Default this to -1 instead of None to avoid operator errors
-    max_steps: Optional[int] = -1
-
-    # NOTE: Packing only works with FA2
-    packing: bool = False  # whether to pack sequences for training
-    use_fa2: bool = False  # FA2 is only available when provider is "huggingface"
-
-    provider: Literal["unsloth", "huggingface"] = "huggingface"
-
-    # Vision training configuration
-    modality: Literal["text", "vision"] = "text"
-
-    max_seq_length: Optional[int] = None  # used to load pretrained models
-    lr_scheduler_type: Optional[str] = "linear"
-    save_strategy: Optional[str] = "epoch"
-    logging_steps: Optional[int] = 10
-
-    # NOTE: Only specify eval_strategy if you actually provide eval_dataset
-    eval_strategy: Optional[str] = "no"  # "no", "steps", "epoch"
-    eval_steps: Optional[int] = 50  # Required if eval_strategy="steps"
-
-    # Metrics configuration, otherwise eval only returns eval loss etc.
-    # if true returns computed metrics ["accuracy", "perplexity"]
-    compute_eval_metrics: Optional[bool] = False
-    # Set to True to enable batch evaluation mode for metrics computation
-    batch_eval_metrics: Optional[bool] = False
-
-
-class WandbConfig(BaseModel):
-    api_key: str
-    # project is defaulted to "huggingface" if not provided
-    project: Optional[str] = None
-    log_model: Optional[Literal["false", "checkpoint", "end"]] = "end"
-
-
-class TrainRequest(BaseModel):
-    # This struct is shared between the API and the backend service
-    processed_dataset_id: str
-    hf_token: str
-    job_name: str = "unnamed job"
-    training_config: TrainingConfig
-    export_config: ExportConfig
-    wandb_config: Optional[WandbConfig] = None
-
-
-class JobSubmitResponse(BaseModel):
-    job_id: str
 
 
 class JobStatusResponse(BaseModel):


### PR DESCRIPTION
This updates preprocessing service for dataset format and types, close #10, #21 

## Summary

- Introduces `processing_mode` for datasets to differentiate between existing language modelling and new types
- Supports prompt-only type that contain `prompt: List[Dict]` and other text-only columns (ignored by `GRPOTrainer` but can be used for reward functions)
- Supports preference type that contain `prompt: List, chosen: List, rejected: List` (used by `DPOTrainer`)
- Refactors the existing helper utils e.g. multimodal handler, message constructors in `formater_converter.py`
- Restructures `user_field` to move from `Dict[str, Any] to List[Dict]` so the user can specify multiple `FieldMapping` in the user_field. This change will deprecate the use of vision fields and enforce that all `type: image` must be set inside `user_field` (which gets mapped to one of `prompt` or `role: user`). This change is backward compatible!!
- Automatically detects pre-formatted messages using a combination of regex and logic checks when `type: column` to avoid double-formatting with ChatML structure

A more detailed documentation was added to `preprocessing/README.md`.

## Note

This PR will make adding support for any other dataset types specified on the [TRL docs](https://huggingface.co/docs/trl/v0.19.0/en/dataset_formats) easy. Note that this project will enforce usage of conversational as opposed to standard dataset format as defined in the docs. More info are discussed in the issue #21 and #38 

This PR will also require a **breaking** frontend overhaul to replace the current dataset preprocessing configuration UI with one that's more flexible and customizable.